### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/config-helper.template
+++ b/config-helper.template
@@ -56,7 +56,7 @@
             "};"
           ]]}
         },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "Timeout": "30"
       }
     },

--- a/iot-backend.template
+++ b/iot-backend.template
@@ -73,7 +73,7 @@
                 "MemorySize" : 128,
                 "Role" : {"Fn::GetAtt" : ["ApiExecutionRole", "Arn"] },
                 "Timeout" : 10,
-                "Runtime" : "nodejs6.10",
+                "Runtime" : "nodejs10.x",
                 "Code" : {
                     "S3Bucket" : { "Ref" : "CodeBucket" },
                     "S3Key" : {"Fn::Join": ["/", [{"Ref": "CodeKeyPrefix"}, "iot_api.zip"]]}
@@ -137,7 +137,7 @@
                 "MemorySize" : 128,
                 "Role" : {"Fn::GetAtt" : ["DdbCloudWatchProcessorRole", "Arn"] },
                 "Timeout" : 10,
-                "Runtime" : "nodejs6.10",
+                "Runtime" : "nodejs10.x",
                 "Code" : {
                     "S3Bucket" : { "Ref" : "CodeBucket" },
                     "S3Key" : {"Fn::Join": ["/", [{"Ref": "CodeKeyPrefix"}, "iot_ddb_cw_eventprocessor.zip"]]}
@@ -155,7 +155,7 @@
                 "MemorySize" : 128,
                 "Role" : {"Fn::GetAtt" : ["EventArchiverRole", "Arn"] },
                 "Timeout" : 10,
-                "Runtime" : "nodejs6.10",
+                "Runtime" : "nodejs10.x",
                 "Code" : {
                     "S3Bucket" : { "Ref" : "CodeBucket" },
                     "S3Key" : {"Fn::Join": ["/", [{"Ref": "CodeKeyPrefix"}, "iot_s3_eventprocessor.zip"]]}


### PR DESCRIPTION
CloudFormation templates in lambda-refarch-iotbackend have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.